### PR TITLE
Stable back

### DIFF
--- a/twister-lib-android/espresso_actors/src/main/java/net/twisterrob/inventory/android/test/actors/ActivityActor.java
+++ b/twister-lib-android/espresso_actors/src/main/java/net/twisterrob/inventory/android/test/actors/ActivityActor.java
@@ -42,10 +42,14 @@ public class ActivityActor {
 		assertClosing(activityClass);
 	}
 	public void assertClosing(Activity activity) {
+		// Synchronize with Espresso in case there's something going on.
+		Espresso.onIdle();
 		assertThat(activity, instanceOf(activityClass));
 		assertThat(activity, isFinishing());
 	}
 	protected <T extends Activity> void assertClosing(Class<T> activityType) {
+		// Synchronize with Espresso in case there's something going on.
+		Espresso.onIdle();
 		// there may be other activities still not fully destroyed, so let's loop
 		for (T activity : getActivitiesByType(activityType)) {
 			assertThat(activity, isFinishing());
@@ -63,14 +67,8 @@ public class ActivityActor {
 	}
 	public void close() {
 		Espresso.pressBack();
-		// Wait for the result of the back-press.
-		// This is necessary in case the next statement executed is not an Espresso-synchronized statement.
-		Espresso.onIdle();
 	}
 	public void closeToKill() {
 		Espresso.pressBackUnconditionally();
-		// Wait for the result of the back-press.
-		// This is necessary in case the next statement executed is not an Espresso-synchronized statement.
-		Espresso.onIdle();
 	}
 }

--- a/twister-lib-android/espresso_actors/src/main/java/net/twisterrob/inventory/android/test/actors/ActivityActor.java
+++ b/twister-lib-android/espresso_actors/src/main/java/net/twisterrob/inventory/android/test/actors/ActivityActor.java
@@ -63,8 +63,14 @@ public class ActivityActor {
 	}
 	public void close() {
 		Espresso.pressBack();
+		// Wait for the result of the back-press.
+		// This is necessary in case the next statement executed is not an Espresso-synchronized statement.
+		Espresso.onIdle();
 	}
 	public void closeToKill() {
 		Espresso.pressBackUnconditionally();
+		// Wait for the result of the back-press.
+		// This is necessary in case the next statement executed is not an Espresso-synchronized statement.
+		Espresso.onIdle();
 	}
 }


### PR DESCRIPTION
Address this failure:
```
java.lang.AssertionError:
Expected: activity finishing is <true>
but: is finishing was <false>
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
at net.twisterrob.inventory.android.test.actors.ActivityActor.assertClosing(ActivityActor.java:46)
at net.twisterrob.inventory.android.activity.ItemEditActivityTest_Edit.testCancel(ItemEditActivityTest_Edit.java:44)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
at androidx.test.internal.runner.junit4.statement.RunBefores.evaluate(RunBefores.java:80)
at net.twisterrob.android.test.junit.IdlingResourceRule$IdlingResourceStatement.evaluate(IdlingResourceRule.java:42)
at net.twisterrob.android.test.espresso.ScreenshotFailure$ScreenshotStatement.evaluate(ScreenshotFailure.java:100)
at net.twisterrob.android.test.junit.SensibleActivityTestRule$TestLogger$1.evaluate(SensibleActivityTestRule.java:138)
at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:549)
at net.twisterrob.android.test.junit.IdlingResourceRule$IdlingResourceStatement.evaluate(IdlingResourceRule.java:42)
at net.twisterrob.inventory.android.test.TestDatabaseRule$DatabaseStatement.evaluate(TestDatabaseRule.java:34)
at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:154)
at org.junit.runners.Suite.runChild(Suite.java:128)
at org.junit.runners.Suite.runChild(Suite.java:27)
at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:395)
at net.twisterrob.android.test.junit.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:82)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1837)
```

```
	@Test public void testCancel() {
		itemEdit.closeToKill(); // presses back
		itemEdit.assertClosing(activity.getActivity()); // checks without waiting
```