### PR TITLE
Make SelectionAdapter only deal with IDs, not positions.

### DIFF
--- a/twister-lib-android/monolith/src/main/java/net/twisterrob/android/view/SelectionAdapter.java
+++ b/twister-lib-android/monolith/src/main/java/net/twisterrob/android/view/SelectionAdapter.java
@@ -113,6 +113,15 @@ public class SelectionAdapter<VH extends RecyclerView.ViewHolder> extends Wrappi
 	}
 
 	@SuppressLint("NotifyDataSetChanged") // The selection is likely non-contiguous, notify to refresh everything. 
+	public void setSelectedIds(@NonNull long[] selection) {
+		selectedItems.clear();
+		for (long id : selection) {
+			selectedItems.add(id);
+		}
+		notifyDataSetChanged();
+	}
+
+	@SuppressLint("NotifyDataSetChanged") // The selection is likely non-contiguous, notify to refresh everything. 
 	public void setSelectedItems(@NonNull Collection<Integer> positions) {
 		selectedItems.clear();
 		for (int position : positions) {

--- a/twister-lib-android/monolith/src/main/java/net/twisterrob/android/view/SelectionAdapter.java
+++ b/twister-lib-android/monolith/src/main/java/net/twisterrob/android/view/SelectionAdapter.java
@@ -24,6 +24,10 @@ public class SelectionAdapter<VH extends RecyclerView.ViewHolder> extends Wrappi
 
 	public SelectionAdapter(Adapter<VH> wrapped) {
 		super(wrapped);
+	}
+
+	@Override protected void setWrappedAdapter(@NonNull RecyclerView.Adapter<VH> wrapped) {
+		super.setWrappedAdapter(wrapped);
 		assert hasStableIds();
 	}
 


### PR DESCRIPTION
This will ensure that the selection is more resilient to invalidation and structural changes.