### PR TITLE
Allow type-safe project accessors in including builds.

### DIFF
--- a/gradle/platform-libs/settings.gradle
+++ b/gradle/platform-libs/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name = "platform-libs"
+
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	versionCatalogs {

--- a/gradle/plugins/settings.gradle.kts
+++ b/gradle/plugins/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "net-twisterrob-libraries-plugins"
+
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	repositories {


### PR DESCRIPTION
Fixes
```
Type-safe project accessors is an incubating feature.
Project accessors enabled, but root project name not explicitly set for 'plugins'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking cachin
g.
Project accessors enabled, but root project name not explicitly set for 'platform-libs'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking
caching.
```