### PR TITLE
Suppress RtlHardcoded

### DIFF
--- a/twister-lib-android/defs/src/main/java/net/twisterrob/android/annotation/GravityFlag.java
+++ b/twister-lib-android/defs/src/main/java/net/twisterrob/android/annotation/GravityFlag.java
@@ -41,8 +41,10 @@ import androidx.core.view.GravityCompat;
 import net.twisterrob.java.annotations.DebugHelper;
 import net.twisterrob.java.utils.StringTools;
 
-@SuppressLint("UseRequiresApi")
-// It is revised for L or below only. Newer features are not supported yet.
+@SuppressLint({
+		"UseRequiresApi", // It is revised for L or below only. Newer features are not supported yet.
+		"RtlHardcoded", // Needed to help consumers do lint.checkDependencies.
+})
 @TargetApi(VERSION_CODES.LOLLIPOP)
 @IntDef(flag = true, value = {
 		Gravity.NO_GRAVITY,


### PR DESCRIPTION
https://github.com/TWiStErRob/net.twisterrob.travel/pull/364 failed without this.

```
* What went wrong:
Execution failed for task ':android:component:map:lintDebug'.
> Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or add the issues to the lint baseline via `gradlew updateLintBaseline`.
  For more details, see https://developer.android.com/studio/write/lint#snapshot
  
  Lint found 4 errors, 0 warnings. First failure:
  
Error:   /home/runner/work/net.twisterrob.travel/net.twisterrob.travel/libs/twister-lib-android/defs/src/main/java/net/twisterrob/android/annotation/GravityFlag.java:51: Error: Use "Gravity.START" instead of "Gravity.LEFT" to ensure correct behavior in right-to-left locales [RtlHardcoded]
    Gravity.LEFT,
            ~~~~
```
