### PR TITLE
SLF4J 2.0.17 behavior change follow-up

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx2048M -Dorg.gradle.deprecation.trace=true
 
 org.gradle.warning.mode=fail
 org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ test-android-objenesis = "2.6"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/allprojects.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/allprojects.gradle.kts
@@ -70,8 +70,12 @@ dependencyAnalysisSub {
 		// There are some configuration in root project's issues.all { ... } block. 
 
 		if (project.path.endsWith("-test_helpers")) {
+			val targetProject = project.path.removeSuffix("-test_helpers")
 			onIncorrectConfiguration {
-				exclude(project.path.removeSuffix("-test_helpers"))
+				exclude(targetProject)
+			}
+			onUnusedDependencies {
+				exclude(targetProject)
 			}
 		}
 		onUnusedDependencies {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/allprojects.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/allprojects.gradle.kts
@@ -63,6 +63,11 @@ afterEvaluate {
 
 tasks.withType<Test>().configureEach test@{
 	systemProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace")
+	jvmArgs(
+		// Reduce occurrences of warning:
+		// > Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
+		"-Xshare:off",
+	)
 }
 
 dependencyAnalysisSub {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/allprojects.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/allprojects.gradle.kts
@@ -65,7 +65,8 @@ tasks.withType<Test>().configureEach test@{
 	systemProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace")
 	jvmArgs(
 		// Reduce occurrences of warning:
-		// > Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
+		// > Java HotSpot(TM) 64-Bit Server VM warning:
+		// > Sharing is only supported for boot loader classes because bootstrap classpath has been appended
 		"-Xshare:off",
 	)
 }

--- a/gradle/settings.substitutions.gradle
+++ b/gradle/settings.substitutions.gradle
@@ -52,6 +52,7 @@ dependencySubstitution {
 	substitute module("net.twisterrob.lib:twister-lib-android-mad") using project(":mad")
 	substitute module("net.twisterrob.lib:twister-lib-android-permissions") using project(":permissions")
 	substitute module("net.twisterrob.lib:twister-lib-android-slf4j") using project(":slf4j")
+	substitute module("net.twisterrob.lib:twister-lib-android-slf4j-test_helpers") using project(":slf4j-test_helpers")
 	substitute module("net.twisterrob.lib:twister-lib-android-stringers") using project(":stringers")
 	substitute module("net.twisterrob.lib:twister-lib-android-uiautomator") using project(":uiautomator")
 	substitute module("net.twisterrob.lib:twister-lib-android-widgets") using project(":widgets")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,7 +44,7 @@ include(":lib:mockito")
 
 includeAndroid(":monolith")
 
-includeAndroid(":slf4j")
+includeAndroidWithTestHelpers(":slf4j")
 includeAndroid(":logging")
 includeAndroid(":stringers")
 

--- a/twister-lib-android/config/lint/lint-baseline-slf4j-test_helpers.xml
+++ b/twister-lib-android/config/lint/lint-baseline-slf4j-test_helpers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.9.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.1)" variant="all" version="8.9.1">
+
+</issues>

--- a/twister-lib-android/logging/build.gradle
+++ b/twister-lib-android/logging/build.gradle
@@ -13,4 +13,9 @@ dependencies {
 	compileOnly(libs.androidx.appcompat)
 	compileOnly(libs.androidx.material)
 	compileOnly(libs.androidx.recyclerview)
+
+	androidTestImplementation "net.twisterrob.lib:twister-lib-android-espresso"
+	androidTestImplementation "net.twisterrob.lib:twister-lib-android-slf4j"
+	androidTestRuntimeOnly(libs.slf4j2.api)
+	androidTestImplementation "net.twisterrob.lib:twister-lib-android-slf4j-test_helpers"
 }

--- a/twister-lib-android/logging/src/androidTest/kotlin/net/twisterrob/android/utils/log/LoggingCursorFactoryTest.kt
+++ b/twister-lib-android/logging/src/androidTest/kotlin/net/twisterrob/android/utils/log/LoggingCursorFactoryTest.kt
@@ -1,0 +1,48 @@
+package net.twisterrob.android.utils.log
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import androidx.test.core.app.ApplicationProvider
+import net.twisterrob.android.log.getLogsFor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LoggingCursorFactoryTest {
+	@Test
+	fun logsQueries() {
+		val context: Context = ApplicationProvider.getApplicationContext()
+		val helper = object : SQLiteOpenHelper(
+			context,
+			"LoggingCursorFactoryTest",
+			LoggingCursorFactory(),
+			1,
+		) {
+			override fun onCreate(db: SQLiteDatabase) {
+				db.execSQL("CREATE TABLE MyTable(col1 TEXT, col2 TEXT);")
+			}
+
+			override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+		}
+		assertEquals(emptyList<String>(), getLogsFor("l_CursorFactory"))
+
+		helper.readableDatabase
+			.query(
+				"MyTable",
+				arrayOf("col1", "col2"),
+				"col1 = ?",
+				arrayOf("value"),
+				null,
+				null,
+				null,
+			)
+			.close()
+
+		assertEquals(
+			listOf(
+				"V/l_CursorFactory: SQLiteQuery: SELECT col1, col2 FROM MyTable WHERE col1 = ?"
+			),
+			getLogsFor("l_CursorFactory"),
+		)
+	}
+}

--- a/twister-lib-android/logging/src/androidTest/kotlin/net/twisterrob/android/utils/log/LoggingCursorFactoryTest.kt
+++ b/twister-lib-android/logging/src/androidTest/kotlin/net/twisterrob/android/utils/log/LoggingCursorFactoryTest.kt
@@ -22,9 +22,10 @@ class LoggingCursorFactoryTest {
 				db.execSQL("CREATE TABLE MyTable(col1 TEXT, col2 TEXT);")
 			}
 
-			override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+			override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+			}
 		}
-		assertEquals(emptyList<String>(), getLogsFor("l_CursorFactory"))
+		assertEquals(emptyList<String>(), getLogsFor("CursorFactory"))
 
 		helper.readableDatabase
 			.query(
@@ -40,9 +41,9 @@ class LoggingCursorFactoryTest {
 
 		assertEquals(
 			listOf(
-				"V/l_CursorFactory: SQLiteQuery: SELECT col1, col2 FROM MyTable WHERE col1 = ?"
+				"V/CursorFactory: SQLiteQuery: SELECT col1, col2 FROM MyTable WHERE col1 = ?"
 			),
-			getLogsFor("l_CursorFactory"),
+			getLogsFor("CursorFactory"),
 		)
 	}
 }

--- a/twister-lib-android/logging/src/androidTest/resources/android-logger.properties
+++ b/twister-lib-android/logging/src/androidTest/resources/android-logger.properties
@@ -1,0 +1,2 @@
+replacement.logging=^net\\.twisterrob\\.android\\.utils\\.log\\.Logging
+replacement.logging.with=l_

--- a/twister-lib-android/logging/src/main/java/net/twisterrob/android/utils/log/LoggingCursorFactory.java
+++ b/twister-lib-android/logging/src/main/java/net/twisterrob/android/utils/log/LoggingCursorFactory.java
@@ -1,4 +1,4 @@
-package net.twisterrob.android.db;
+package net.twisterrob.android.utils.log;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/twister-lib-android/logging/src/main/java/net/twisterrob/android/utils/log/LoggingCursorFactory.java
+++ b/twister-lib-android/logging/src/main/java/net/twisterrob/android/utils/log/LoggingCursorFactory.java
@@ -18,7 +18,7 @@ import net.twisterrob.java.annotations.DebugHelper;
 @RequiresApi(VERSION_CODES.HONEYCOMB)
 @DebugHelper
 public final class LoggingCursorFactory implements CursorFactory {
-	private static final Logger LOG = LoggerFactory.getLogger(LoggingCursorFactory.class);
+	private static final Logger LOG = LoggerFactory.getLogger("CursorFactory");
 
 	@Override public Cursor newCursor(SQLiteDatabase db,
 			SQLiteCursorDriver masterQuery, String editTable, SQLiteQuery query) {

--- a/twister-lib-android/monolith/src/main/java/net/twisterrob/android/db/DatabaseOpenHelper.java
+++ b/twister-lib-android/monolith/src/main/java/net/twisterrob/android/db/DatabaseOpenHelper.java
@@ -28,6 +28,7 @@ import android.os.Environment;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.WorkerThread;
 
+import net.twisterrob.android.utils.log.LoggingCursorFactory;
 import net.twisterrob.android.utils.tools.DatabaseTools;
 import net.twisterrob.android.utils.tools.IOTools;
 import net.twisterrob.java.annotations.DebugHelper;

--- a/twister-lib-android/slf4j/build.gradle
+++ b/twister-lib-android/slf4j/build.gradle
@@ -10,4 +10,8 @@ configurations {
 dependencies {
 	compileOnly(libs.androidx.annotation)
 	api(libs.slf4j.api)
+
+	androidTestImplementation "net.twisterrob.lib:twister-lib-android-espresso"
+	// Test with v1 here, and v2 everywhere else (:logging module).
+	androidTestImplementation(libs.slf4j.api)
 }

--- a/twister-lib-android/slf4j/build.gradle
+++ b/twister-lib-android/slf4j/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 	androidTestImplementation "net.twisterrob.lib:twister-lib-android-espresso"
 	// Test with v1 here, and v2 everywhere else (:logging module).
-	androidTestImplementation(libs.slf4j.api)
+	androidTestRuntimeOnly(libs.slf4j.api)
 }

--- a/twister-lib-android/slf4j/src/androidTest/kotlin/net/twisterrob/android/log/AndroidLoggerServiceProviderTest.kt
+++ b/twister-lib-android/slf4j/src/androidTest/kotlin/net/twisterrob/android/log/AndroidLoggerServiceProviderTest.kt
@@ -1,0 +1,17 @@
+package net.twisterrob.android.log
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.slf4j.LoggerFactory
+
+class AndroidLoggerServiceProviderTest {
+
+	@Test
+	fun test() {
+		val logger = LoggerFactory.getLogger("MyLogs")
+
+		assertNotNull(logger)
+		assertEquals(AndroidLogger::class, logger::class)
+	}
+}

--- a/twister-lib-android/slf4j/src/androidTest/kotlin/net/twisterrob/android/log/AndroidLoggerTest.kt
+++ b/twister-lib-android/slf4j/src/androidTest/kotlin/net/twisterrob/android/log/AndroidLoggerTest.kt
@@ -1,0 +1,28 @@
+package net.twisterrob.android.log
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AndroidLoggerTest {
+	@Test
+	fun logsMessages() {
+		val logger = AndroidLogger("My Long Name", "My Short Name", "MyTag")
+
+		logger.trace("My trace Message")
+		logger.debug("My debug Message")
+		logger.info("My info Message")
+		logger.warn("My warn Message")
+		logger.error("My error Message")
+
+		assertEquals(
+			listOf(
+				"V/MyTag   : My trace Message",
+				"D/MyTag   : My debug Message",
+				"I/MyTag   : My info Message",
+				"W/MyTag   : My warn Message",
+				"E/MyTag   : My error Message",
+			),
+			getLogsFor("MyTag"),
+		)
+	}
+}

--- a/twister-lib-android/slf4j/src/androidTest/kotlin/net/twisterrob/android/log/getLogsFor.kt
+++ b/twister-lib-android/slf4j/src/androidTest/kotlin/net/twisterrob/android/log/getLogsFor.kt
@@ -1,0 +1,24 @@
+package net.twisterrob.android.log
+
+internal fun getLogsFor(tag: String, format: String = "tag"): List<String> {
+	// -d: dump and stop, don't block
+	// -b main: app's logs
+	// -v ...: output format
+	// -s: silent by default
+	// tag:level: only interested in logs for specific tag
+	val command = "logcat -d -b main -v ${format} -s ${tag}"
+	val process = Runtime.getRuntime().exec(command)
+	val exit = process.waitFor()
+	val error = process.errorStream
+		.bufferedReader()
+		.readText()
+		.takeIf(String::isNotEmpty)
+	if (error != null || exit != 0) {
+		error("Error running command: ${command}\nExit: ${exit}\n${error}")
+	}
+	val output = process.inputStream
+		.bufferedReader()
+		.lineSequence()
+		.toList()
+	return output.dropWhile { it == "--------- beginning of main" }
+}

--- a/twister-lib-android/slf4j/src/main/java/net/twisterrob/android/log/AndroidLoggerServiceProvider.kt
+++ b/twister-lib-android/slf4j/src/main/java/net/twisterrob/android/log/AndroidLoggerServiceProvider.kt
@@ -10,7 +10,7 @@ import org.slf4j.spi.SLF4JServiceProvider
 // TODO revert to earlier state with val/vars https://youtrack.jetbrains.com/issue/KT-6653#focus=Comments-27-9920359.0-0
 class AndroidLoggerServiceProvider : SLF4JServiceProvider {
 
-	private val requestedApiVersion: String = "2.0.13"
+	private val requestedApiVersion: String = "2.0.17"
 	override fun getRequestedApiVersion(): String =
 		requestedApiVersion
 

--- a/twister-lib-android/slf4j/src/main/java/net/twisterrob/android/log/AndroidLoggerServiceProvider.kt
+++ b/twister-lib-android/slf4j/src/main/java/net/twisterrob/android/log/AndroidLoggerServiceProvider.kt
@@ -18,17 +18,15 @@ class AndroidLoggerServiceProvider : SLF4JServiceProvider {
 	override fun getLoggerFactory(): ILoggerFactory =
 		loggerFactory
 
-	private lateinit var markerFactory: IMarkerFactory
+	private val markerFactory: IMarkerFactory = BasicMarkerFactory()
 	override fun getMarkerFactory(): IMarkerFactory =
 		markerFactory
 
-	private lateinit var mdcAdapter: MDCAdapter
+	private val mdcAdapter: MDCAdapter = NOPMDCAdapter()
 	override fun getMDCAdapter(): MDCAdapter =
 		mdcAdapter
 
 	override fun initialize() {
 		loggerFactory = AndroidLoggerFactory()
-		markerFactory = BasicMarkerFactory()
-		mdcAdapter = NOPMDCAdapter()
 	}
 }

--- a/twister-lib-android/slf4j/test_helpers/build.gradle
+++ b/twister-lib-android/slf4j/test_helpers/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+	id("net.twisterrob.libraries.android.test-helpers")
+}
+
+dependencies {
+	implementation(libs.kotlin.stdlib)
+}

--- a/twister-lib-android/slf4j/test_helpers/src/main/kotlin/net/twisterrob/android/log/getLogsFor.kt
+++ b/twister-lib-android/slf4j/test_helpers/src/main/kotlin/net/twisterrob/android/log/getLogsFor.kt
@@ -1,6 +1,6 @@
 package net.twisterrob.android.log
 
-internal fun getLogsFor(tag: String, format: String = "tag"): List<String> {
+fun getLogsFor(tag: String, format: String = "tag"): List<String> {
 	// -d: dump and stop, don't block
 	// -b main: app's logs
 	// -v ...: output format


### PR DESCRIPTION
Follow-up on https://github.com/TWiStErRob/net.twisterrob.libraries/pull/232
Fixing https://github.com/TWiStErRob/net.twisterrob.inventory/pull/512 (https://github.com/qos-ch/slf4j/issues/450#issuecomment-2817349106) + tests for regression.

Also fix:

> Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended