### PR TITLE
Update Mockito-Kotlin from 6.2.3 to 6.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ test-junit = "4.13.2"
 test-params = "1.1.1"
 test-gwen = "1.0.2"
 test-mockito = "5.20.0"
-test-mockitoKotlin = "6.2.3"
+test-mockitoKotlin = "6.3.0"
 # Use this instead of 1.3
 # If `hamcrest-1.3` appears in the dependency list, check if it's excluded from all usages.
 test-hamcrest = "2.0.0.0"


### PR DESCRIPTION
## Summary

Updates only `org.mockito.kotlin:mockito-kotlin` from 6.2.3 to 6.3.0.

Mockito itself remains pinned at 5.20.0 because versions 5.21–5.23 break the API 21 instrumentation tests in #340. Splitting the dependencies allows the Kotlin integration update to proceed independently.

## Validation

CI will perform validation.