### PR TITLE
Raise Android compileSdk from 35 to 36

### DIFF
--- a/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/android.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/android.base.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
 android {
 	namespace = project.autoNamespace
-	compileSdk = 35
+	compileSdk = 36
 	defaultConfig {
 		minSdk = 21
 	}


### PR DESCRIPTION
## Summary

Raises the shared Android convention plugin `compileSdk` from 35 to 36 for all Android modules, including `:espresso_glide4`.

This is required by OkHttp 5.4.0, which requires consumers to compile against Android API 36 or newer. It is separated from the OkHttp dependency update so the platform change can be reviewed independently.

## Validation

CI will validate this change.