### PR TITLE
Raise Android compileSdk from 36 to 37

### DIFF
--- a/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/android.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/android.base.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
 android {
 	namespace = project.autoNamespace
-	compileSdk = 36
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 21
 	}

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/android.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/libraries/build/android.base.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
 android {
 	namespace = project.autoNamespace
-	compileSdk = 35
+	compileSdk = 36
 	defaultConfig {
 		minSdk = 21
 	}


### PR DESCRIPTION
## Summary

Stacked on #376, raises the shared Android convention plugin `compileSdk` from 36 to 37 for all Android modules.

This exploratory follow-up lets CI identify any additional compatibility issues before the dependency upgrades that require newer Android APIs.

## Validation

CI will validate this change.